### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+nginx/log
+html/wp-content/cache
+htlm/wp-content/debug.log


### PR DESCRIPTION
Makes it easier to manually synchronize workspaces.
Logs and cache should not be shared between workspaces.