### PR TITLE
Increase pm.max_children from 5 to 10 

### DIFF
--- a/php/pool.d/www.conf
+++ b/php/pool.d/www.conf
@@ -110,7 +110,7 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 5
+pm.max_children = 10
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'


### PR DESCRIPTION
because a boost plan or higher should easily have enough RAM to support that and we experienced better user experience on sites where the value is higher than 5.