### PR TITLE
Add fastcgi buffer config

### DIFF
--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -33,8 +33,8 @@ server {
 		# With php-cgi (or other tcp sockets):
 		# fastcgi_pass 127.0.0.1:9000;
 		fastcgi_buffers 16 32k;
-        fastcgi_buffer_size 64k;
-        fastcgi_busy_buffers_size 64k;
+		fastcgi_buffer_size 64k;
+		fastcgi_busy_buffers_size 64k;
 	}
 
 	# deny access to .htaccess files, if Apache's document root

--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -32,6 +32,9 @@ server {
 		fastcgi_pass unix:/tmp/run/php-fpm.sock;
 		# With php-cgi (or other tcp sockets):
 		# fastcgi_pass 127.0.0.1:9000;
+		fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
 	}
 
 	# deny access to .htaccess files, if Apache's document root

--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -32,9 +32,6 @@ server {
 		fastcgi_pass unix:/tmp/run/php-fpm.sock;
 		# With php-cgi (or other tcp sockets):
 		# fastcgi_pass 127.0.0.1:9000;
-		fastcgi_buffers 16 32k;
-		fastcgi_buffer_size 64k;
-		fastcgi_busy_buffers_size 64k;
 	}
 
 	# deny access to .htaccess files, if Apache's document root

--- a/nginx/snippets/fastcgi-php.conf
+++ b/nginx/snippets/fastcgi-php.conf
@@ -9,5 +9,10 @@ try_files $fastcgi_script_name =404;
 set $path_info $fastcgi_path_info;
 fastcgi_param PATH_INFO $path_info;
 
+# Set fastcgi buffer size
+fastcgi_buffers 16 32k;
+fastcgi_buffer_size 64k;
+fastcgi_busy_buffers_size 64k;
+
 fastcgi_index index.php;
 include /etc/nginx/fastcgi.conf;

--- a/nginx/snippets/fastcgi-php.conf
+++ b/nginx/snippets/fastcgi-php.conf
@@ -10,9 +10,9 @@ set $path_info $fastcgi_path_info;
 fastcgi_param PATH_INFO $path_info;
 
 # Set fastcgi buffer size
-fastcgi_buffers 16 32k;
-fastcgi_buffer_size 64k;
-fastcgi_busy_buffers_size 64k;
+fastcgi_buffers 8 8k;
+fastcgi_buffer_size 16k;
+fastcgi_busy_buffers_size 16k;
 
 fastcgi_index index.php;
 include /etc/nginx/fastcgi.conf;


### PR DESCRIPTION
### Added
- fastcgi buffer config to prevent php from sending `upstream sent too big header` error.