### PR TITLE
Fix indentation in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -48,7 +48,8 @@ php-fpm${VERSION} -y $SCRIPTPATH/php/php-fpm.conf
 
 trap stop_php EXIT
 
-if $ENABLE_COMMIT_CRON then
+if $ENABLE_COMMIT_CRON
+then
     start_commit_cron
     trap stop_commit_cron EXIT
 fi


### PR DESCRIPTION
### Fixed
- Start script indentation in cron commit block that prevents wordpress website from running normally.