### PR TITLE
Up php timeout

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,7 +45,7 @@ http {
 	fastcgi_temp_path /home/user/app/nginx/fastcgi;
 	uwsgi_temp_path /home/user/app/nginx/uwsgi;
 	scgi_temp_path /home/user/app/nginx/scgi;
-	
+
 	access_log /tmp/log/nginx-access.log;
 	access_log /dev/stdout;
 

--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -11,6 +11,12 @@ server {
 
 	client_max_body_size 500M;
 
+    proxy_read_timeout 600s;
+    proxy_connect_timeout 600s;
+    proxy_send_timeout 600s;
+    fastcgi_send_timeout 600s;
+    fastcgi_read_timeout 600s;
+
 	root /home/user/app/html;
 	index index.php;
 
@@ -27,7 +33,7 @@ server {
 	#
 	location ~ \.php$ {
 		include /home/user/app/nginx/snippets/fastcgi-php.conf;
-	
+
 		# With php-fpm (or other unix sockets):
 		fastcgi_pass unix:/tmp/run/php-fpm.sock;
 		# With php-cgi (or other tcp sockets):

--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -6,10 +6,10 @@
 # Default php wordpress configuration
 #
 server {
-	listen 3000 default_server;
-	listen [::]:3000 default_server;
+    listen 3000 default_server;
+    listen [::]:3000 default_server;
 
-	client_max_body_size 500M;
+    client_max_body_size 500M;
 
     proxy_read_timeout 600s;
     proxy_connect_timeout 600s;
@@ -17,38 +17,38 @@ server {
     fastcgi_send_timeout 600s;
     fastcgi_read_timeout 600s;
 
-	root /home/user/app/html;
-	index index.php;
+    root /home/user/app/html;
+    index index.php;
 
-	server_name _;
-	include /home/user/app/nginx/snippets/error_pages.conf;
+    server_name _;
+    include /home/user/app/nginx/snippets/error_pages.conf;
 
-	location / {
-		# Static content.
+    location / {
+    	# Static content.
         # include the "?$args" part so non-default permalinks doesn't break when using query string
-		try_files $uri $uri/ /index.php?$args;
-	}
+    	try_files $uri $uri/ /index.php?$args;
+    }
 
-	# pass PHP scripts to FastCGI server
-	#
-	location ~ \.php$ {
-		include /home/user/app/nginx/snippets/fastcgi-php.conf;
+    # pass PHP scripts to FastCGI server
+    #
+    location ~ \.php$ {
+    	include /home/user/app/nginx/snippets/fastcgi-php.conf;
 
-		# With php-fpm (or other unix sockets):
-		fastcgi_pass unix:/tmp/run/php-fpm.sock;
-		# With php-cgi (or other tcp sockets):
-		# fastcgi_pass 127.0.0.1:9000;
-	}
+    	# With php-fpm (or other unix sockets):
+    	fastcgi_pass unix:/tmp/run/php-fpm.sock;
+    	# With php-cgi (or other tcp sockets):
+    	# fastcgi_pass 127.0.0.1:9000;
+    }
 
-	# deny access to .htaccess files, if Apache's document root
-	# concurs with nginx's one
-	#
-	location ~ /\.ht {
-		deny all;
-	}
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    location ~ /\.ht {
+    	deny all;
+    }
 
-	location ~* \.(js|css|png|jpg|jpeg|gif|ico|woff|woff2)$ {
-		expires max;
-		log_not_found off;
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|woff|woff2)$ {
+    	expires max;
+    	log_not_found off;
     }
 }

--- a/php/php.ini
+++ b/php/php.ini
@@ -385,7 +385,7 @@ expose_php = On
 ; Maximum execution time of each script, in seconds
 ; http://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
-max_execution_time = 20
+max_execution_time = 600
 
 ; Maximum amount of time each script may spend parsing request data. It's a good
 ; idea to limit this time on productions servers in order to eliminate unexpectedly

--- a/php/pool.d/www.conf
+++ b/php/pool.d/www.conf
@@ -337,7 +337,7 @@ request_slowlog_timeout = 15
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_terminate_timeout = 25
+request_terminate_timeout = 600
 
 ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
 ; application calls 'fastcgi_finish_request' or when application has finished and

--- a/php/pool.d/www.conf
+++ b/php/pool.d/www.conf
@@ -337,7 +337,7 @@ request_slowlog_timeout = 15
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_terminate_timeout = 600
+request_terminate_timeout = 610
 
 ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
 ; application calls 'fastcgi_finish_request' or when application has finished and


### PR DESCRIPTION
Increase timeouts for wordpress shops because plugin updates can take multiple minutes and will leave the website in an inconsistent state if aborted.