### PR TITLE
increase proxy buffers

### DIFF
--- a/nginx/sites-enabled/default
+++ b/nginx/sites-enabled/default
@@ -17,6 +17,10 @@ server {
     fastcgi_send_timeout 600s;
     fastcgi_read_timeout 600s;
 
+    proxy_buffer_size 128k;
+    proxy_buffers 4 256k;
+    proxy_busy_buffers_size 256k;
+
     root /home/user/app/html;
     index index.php;
 


### PR DESCRIPTION
set recommended buffers according to 
[https://support.plesk.com/hc/en-us/articles/12377655871767-Websites-hosted-on-Plesk-s[…]y-upstream-sent-too-big-header-while-reading-response-header](https://support.plesk.com/hc/en-us/articles/12377655871767-Websites-hosted-on-Plesk-server-are-unavailable-with-502-Bad-Gateway-upstream-sent-too-big-header-while-reading-response-header)