### PR TITLE
Enable file based opcache for phpfpm 

### DIFF
--- a/php/php.ini
+++ b/php/php.ini
@@ -1766,20 +1766,20 @@ ldap.max_links = -1
 
 [opcache]
 ; Determines if Zend OPCache is enabled
-;opcache.enable=1
+opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-;opcache.memory_consumption=128
+opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
 ;opcache.interned_strings_buffer=8
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 1000000 are allowed.
-;opcache.max_accelerated_files=10000
+opcache.max_accelerated_files=10000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ;opcache.max_wasted_percentage=5
@@ -1829,14 +1829,14 @@ ldap.max_links = -1
 
 ; Check the cache checksum each N requests.
 ; The default value of "0" means that the checks are disabled.
-;opcache.consistency_checks=0
+opcache.consistency_checks=100
 
 ; How long to wait (in seconds) for a scheduled restart to begin if the cache
 ; is not being accessed.
 ;opcache.force_restart_timeout=180
 
 ; OPcache error_log file name. Empty string assumes "stderr".
-;opcache.error_log=
+opcache.error_log="/tmp/log/opcache-error.log"
 
 ; All OPcache errors go to the Web server log.
 ; By default, only fatal errors (level 0) or errors (level 1) are logged.
@@ -1868,13 +1868,13 @@ ldap.max_links = -1
 ; Enables and sets the second level cache directory.
 ; It should improve performance when SHM memory is full, at server restart or
 ; SHM reset. The default "" disables file based caching.
-;opcache.file_cache=
+opcache.file_cache="/tmp"
 
 ; Enables or disables opcode caching in shared memory.
-;opcache.file_cache_only=0
+opcache.file_cache_only=0
 
 ; Enables or disables checksum validation when script loaded from file cache.
-;opcache.file_cache_consistency_checks=1
+opcache.file_cache_consistency_checks=1
 
 ; Implies opcache.file_cache_only=1 for a certain process that failed to
 ; reattach to the shared memory (for Windows only). Explicitly enabled file

--- a/php/php.ini
+++ b/php/php.ini
@@ -1788,7 +1788,7 @@ opcache.max_accelerated_files=10000
 ; directory to the script key, thus eliminating possible collisions between
 ; files with the same name (basename). Disabling the directive improves
 ; performance, but may break existing applications.
-;opcache.use_cwd=1
+opcache.use_cwd=0
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.

--- a/php/php.ini
+++ b/php/php.ini
@@ -1788,7 +1788,7 @@ opcache.max_accelerated_files=10000
 ; directory to the script key, thus eliminating possible collisions between
 ; files with the same name (basename). Disabling the directive improves
 ; performance, but may break existing applications.
-opcache.use_cwd=0
+opcache.use_cwd=1
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.


### PR DESCRIPTION
for improved performance after server start and make other settings explicit (don't rely on default).